### PR TITLE
Update examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -54,8 +54,12 @@ $ vi greeter_server/main.go
     	}
 
     	m := cmux.New(lis)
-    	httpL := m.Match(cmux.HTTP1())
-    	grpcL := m.Match(cmux.Any())
+      // Using MatchWithWriters/SendSettings is a major performance hit (around 15%).
+      // Per the cmux documentation, you have to do this for grpc-java.
+      // If only using golang, you don't need this, but probably not
+      // great to assume what the calling languages are.
+      grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldPrefixSendSettings("content-type", "application/grpc"))
+      httpL := m.Match(cmux.Any())
 
     	srv := &server{}
 


### PR DESCRIPTION
This updates `examples/README.md` to show a couple things:

- Use `cmux.HTTP2MatchHeaderFieldPrefixSendSettings` to match gRPC. See https://github.com/soheilhy/cmux/pull/50 for an explanation.
- Match gRPC before anything else for performance.
- Use `MatchWithWriters` and comment why.